### PR TITLE
Fire mode cycling + Coding convensions

### DIFF
--- a/CaptainShotgunModesPlugin.cs
+++ b/CaptainShotgunModesPlugin.cs
@@ -82,17 +82,25 @@ namespace CaptainShotgunModes
         {
             if (Input.GetKeyDown(KeyCode.Alpha1))
             {
-                fireMode = FireMode.Normal;
-            }
+                switch (fireMode)
+                {
+                    case FireMode.Normal:
+                        fireMode = FireMode.Auto;
+                        break;
 
-            if (Input.GetKeyDown(KeyCode.Alpha2))
-            {
-                fireMode = FireMode.Auto;
-            }
+                    case FireMode.Auto:
+                        fireMode = FireMode.AutoCharge;
+                        break;
 
-            if (Input.GetKeyDown(KeyCode.Alpha3))
-            {
-                fireMode = FireMode.AutoCharge;
+                    case FireMode.AutoCharge:
+                        fireMode = FireMode.Normal;
+                        break;
+
+                    default:
+                        // this fire mode isn't implemented yet!
+                        fireMode = FireMode.Normal;
+                        break;
+                }
             }
 
             // TODO: add gamepad button to cycle through fire modes

--- a/CaptainShotgunModesPlugin.cs
+++ b/CaptainShotgunModesPlugin.cs
@@ -47,14 +47,11 @@ namespace CaptainShotgunModes
         
         private void SingleFireMode()
         {
-            if (fireMode.Equals(FireMode.Normal))
-            {
-                orig.Invoke(self);
+            orig.Invoke(self);
 
-                if (self.GetFieldValue<bool>("released"))
-                {
-                    fixedAge = 0;
-                }
+            if (self.GetFieldValue<bool>("released"))
+            {
+                fixedAge = 0;
             }
         }
         
@@ -103,12 +100,12 @@ namespace CaptainShotgunModes
         {
             orig.Invoke(self);
 
-            if (self.targetSkill && self.targetSkillSlot.Equals(SkillSlot.Primary))
+            if (self.targetSkill && self.targetSkillSlot == SkillSlot.Primary)
             {
                 SurvivorIndex survivorIndex =
                     SurvivorCatalog.GetSurvivorIndexFromBodyIndex(self.targetSkill.characterBody.bodyIndex);
 
-                if (survivorIndex.Equals(SurvivorIndex.Captain))
+                if (survivorIndex == SurvivorIndex.Captain)
                 {
                     self.stockText.gameObject.SetActive(true);
                     self.stockText.fontSize = 12f;

--- a/CaptainShotgunModesPlugin.cs
+++ b/CaptainShotgunModesPlugin.cs
@@ -51,7 +51,8 @@ namespace CaptainShotgunModes
             {
                 orig.Invoke(self);
 
-                if (self.GetFieldValue<bool>("released")) {
+                if (self.GetFieldValue<bool>("released"))
+                {
                     fixedAge = 0;
                 }
             }
@@ -59,8 +60,8 @@ namespace CaptainShotgunModes
         
         private void AutoFireMode()
         {
-            bool didFire = false;
-            bool released = self.GetFieldValue<bool>("released");
+            var didFire = false;
+            var released = self.GetFieldValue<bool>("released");
 
             if (!released)
             {
@@ -79,9 +80,9 @@ namespace CaptainShotgunModes
         
         private void AutoFireChargeMode()
         {
-            bool didFire = false;
-            bool released = self.GetFieldValue<bool>("released");
-            float chargeDuration = self.GetFieldValue<float>("chargeDuration");
+            var didFire = false;
+            var released = self.GetFieldValue<bool>("released");
+            var chargeDuration = self.GetFieldValue<float>("chargeDuration");
 
             if (!released && fixedAge >= chargeDuration)
             {

--- a/CaptainShotgunModesPlugin.cs
+++ b/CaptainShotgunModesPlugin.cs
@@ -23,6 +23,30 @@ namespace CaptainShotgunModes
         {
             fixedAge += Time.fixedDeltaTime;
 
+            switch (fireMode)
+            {
+                case FireMode.Normal:
+                    FireSingleMode();
+                    break;
+
+                case FireMode.Auto:
+                    FireAutoMode();
+                    break;
+                
+                case FireMode.AutoCharge:
+                    FireAutoChargeMode();
+                    break;
+
+                default:
+                    // ERROR: fire mode isn't implemented yet
+                    // fallback to single fire mode
+                    FireModeSingle();
+                    break;
+            }
+        }
+        
+        private void SingleFireMode()
+        {
             if (fireMode.Equals(FireMode.Normal))
             {
                 orig.Invoke(self);
@@ -30,16 +54,36 @@ namespace CaptainShotgunModes
                 if (self.GetFieldValue<bool>("released")) {
                     fixedAge = 0;
                 }
+            }
+        }
+        
+        private void AutoFireMode()
+        {
+            bool didFire = false;
+            bool released = self.GetFieldValue<bool>("released");
 
-                return;
+            if (!released)
+            {
+                didFire = true;
+                fixedAge = 0;
+                self.SetFieldValue("released", true);
             }
 
+            orig.Invoke(self);
+
+            if (didFire)
+            {
+                self.SetFieldValue("released", false);
+            }
+        }
+        
+        private void AutoFireChargeMode()
+        {
             bool didFire = false;
-            bool charge = fireMode.Equals(FireMode.AutoCharge);
             bool released = self.GetFieldValue<bool>("released");
             float chargeDuration = self.GetFieldValue<float>("chargeDuration");
 
-            if (!released && (!charge || (charge && fixedAge >= chargeDuration)))
+            if (!released && fixedAge >= chargeDuration)
             {
                 didFire = true;
                 fixedAge = 0;
@@ -97,7 +141,8 @@ namespace CaptainShotgunModes
                         break;
 
                     default:
-                        // this fire mode isn't implemented yet!
+                        // ERROR: fire mode isn't implemented yet
+                        // fallback to single fire mode
                         fireMode = FireMode.Normal;
                         break;
                 }

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 This mod allows you to choose between 3 firing modes for the captain's shotgun: Normal, Auto and AutoCharge. With both auto modes you can just hold down the fire key and don´t have to spam it.
 
-The modes can be selected using the number keys `1`, `2` and `3`. The current mode is displayed above the primary skill icon.
+You can cycle through the fire modes using number key '1'. The current mode is displayed above the primary skill icon.
 
 ## Modes
 
-| Mode       | Key | Description | Screenshot |
-|------------|-----|-------------|------------|
-| Normal     |  1  | The default mode/behavior of the captain's shotgun. | ![normal](https://raw.githubusercontent.com/Vl4dimyr/CaptainShotgunModes/master/images/sc_normal.jpg)
-| Auto       |  2  | Automatically fires as long as the fire key is pressed. | ![auto](https://raw.githubusercontent.com/Vl4dimyr/CaptainShotgunModes/master/images/sc_auto.jpg)
-| AutoCharge |  3  | Automatically fires after charging as long as the fire key is pressed. | ![auto_charge](https://raw.githubusercontent.com/Vl4dimyr/CaptainShotgunModes/master/images/sc_auto_charge.jpg)
+| Mode       | Description | Screenshot |
+|------------|-------------|------------|
+| Normal     | The default mode/behavior of the captain's shotgun. | ![normal](https://raw.githubusercontent.com/Vl4dimyr/CaptainShotgunModes/master/images/sc_normal.jpg)
+| Auto       | Automatically fires as long as the fire key is pressed. | ![auto](https://raw.githubusercontent.com/Vl4dimyr/CaptainShotgunModes/master/images/sc_auto.jpg)
+| AutoCharge | Automatically fires after charging as long as the fire key is pressed. | ![auto_charge](https://raw.githubusercontent.com/Vl4dimyr/CaptainShotgunModes/master/images/sc_auto_charge.jpg)
 
 > I will add controller support if enough players want it! [let me know](https://github.com/Vl4dimyr/CaptainShotgunModes/issues/1).
 


### PR DESCRIPTION
Hi!

Used your mod and really like it!
When you mentioned that gamepads would be supported if enough people wanted it, I immediately went to work.

A couple of changes have been made to make it compliant with C#'s Coding Conventions, and to follow general programming idioms (single responsebility).

In addition, I changed the way fire modes are selected in preparation work for gamepad support.
Now users cycle through the fire modes using number key 1.
This way you only have to modify the check for if the fire mode cycle button has been pressed.

I'm uncertain if they use Unity's new input manager, but if they don't getting gamepad support will be challenging:
![gamepad layout old input manager](https://answers.unity.com/storage/temp/134371-xbox-one-controller-unity-windows-macos.jpg)

One idea could be to convert the mod by creating new skills instead for the additional fire modes.
If the ability to change fire mode during the run needs to be present, you could use skill_swap to swap the fire skill.

At last, I sadly won't be able to reply promptly.
Feel free to only take the bits you like!