### PR TITLE
New method of loading icon sprite.

### DIFF
--- a/RiskOfOptionsMod.cs
+++ b/RiskOfOptionsMod.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using BepInEx.Bootstrap;
 using BepInEx.Configuration;
@@ -33,18 +32,17 @@ namespace CaptainShotgunModes
         {
             ModSettingsManager.SetModDescription(description);
 
-            using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("icon")) {
-                Texture2D texture = new Texture2D(0, 0);
-                byte[] imgData = new byte[stream.Length];
+            using var stream = GetType().Assembly.GetManifestResourceStream("icon");
+            var texture = new Texture2D(0, 0);
+            var imgData = new byte[stream.Length];
 
-                stream.Read(imgData, 0, (int) stream.Length);
+            stream.Read(imgData, 0, imgData.Length);
 
-                if (ImageConversion.LoadImage(texture, imgData))
-                {
-                    ModSettingsManager.SetModIcon(
-                        Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new Vector2(0, 0))
-                    );
-                }
+            if (ImageConversion.LoadImage(texture, imgData))
+            {
+                ModSettingsManager.SetModIcon(
+                    Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new Vector2(0, 0))
+                );
             }
         }
 


### PR DESCRIPTION
Hewwos again :D

I think I've settled on a slightly different way of loading in the sprite for Roo. It's not a major change, but I'm gonna use this method for my mods in the future, if at the very least just because it looks sleeker in my opinion (unless it turns out that it's actually rally bad). 

 know the git diff will show the differences, but lemme explain:
* `Assembly.GetExecutingAssembly().GetManifestResourceStream("icon")` -> `GetType().Assembly.GetManifestResourceStream("icon")` removes the need for the `using System.Reflection;`
* `stream.Read(imgData, 0, (int) stream.Length);` -> `new byte[stream.Length]` removes the need for the explicit cast, since `new byte[stream.Length]` does so implicitly. 
* `using (...) { ... }` -> `using ...;` just looks shorter. Produces the exact same bytecode though (try/catch/finally block).

As always, up to you! Just though I'd share what I discovered (still learning Microsoft's SDK). Thanks again for making the mod in the first place!